### PR TITLE
Now quitting SMTP connection

### DIFF
--- a/validate_email.py
+++ b/validate_email.py
@@ -102,12 +102,19 @@ def validate_email(email, check_mx=False,verify=False):
                 try:
                     smtp = smtplib.SMTP()
                     smtp.connect(mx[1])
-                    if not verify: return True
+                    if not verify:
+                        smtp.quit()
+                        return True
                     status, _ = smtp.helo()
-                    if status != 250: continue
+                    if status != 250:
+                        smtp.quit()
+                        continue
                     smtp.mail('')
                     status, _ = smtp.rcpt(email)
-                    if status != 250: return False
+                    if status != 250:
+                        smtp.quit()
+                        return False
+                    smtp.quit()
                     break
                 except smtplib.SMTPServerDisconnected: #Server not permits verify user
                     break


### PR DESCRIPTION
I had some issues with checking lots of e-mail addresses. After a while everything locked up. Frustrated, I left my code. Now, a couple of weeks later, that I got back to it, it struck me that maybe it's considered impolite by the SMTP servers to have too many open connections to the same server(s), resulting in them refusing connections and/or to give valid responses. Unfortunately, I was unable to reproduce the problem, but I added the smtp.quit() a handful of places anyway, as I think it doesn't hurt anyone to quit the connections.
