### PR TITLE
Feature/catchall

### DIFF
--- a/validate_email.py
+++ b/validate_email.py
@@ -215,7 +215,7 @@ if __name__ == "__main__":
 
         logging.basicConfig()
 
-        result = validate_email(email, mx, validate, noca, debug=True, smtp_timeout=1)
+        result = validate_email(email, mx, validate, noca, debug=False, smtp_timeout=1)
         if result:
             print("Valid!")
         elif result is None:

--- a/validate_email.py
+++ b/validate_email.py
@@ -169,6 +169,9 @@ def validate_email(email, check_mx=False, verify=False, catchall=False, debug=Fa
                         if status == 250:
                             smtp.quit()
                             return False
+                        if status == 550:
+                            smtp.quit()
+                            return True
                     if status == 250:
                         smtp.quit()
                         return True


### PR DESCRIPTION
Option 'cathcall' will not validate email addresses when they are on a catch-all domain :)
Sometimes this is handy ....

Enter email for validation: _email_address@catchall.domain_
Validate MX record? [yN] y
Try to contact server for address validation? [yN] y
Accept catch-all? [yN] y
_Valid!_
Enter email for validation: _email_address@catchall.domain_
Validate MX record? [yN] y
Try to contact server for address validation? [yN] y
Accept catch-all? [yN] n
_Invalid!_
