### PR TITLE
Add ability to specify sending email

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,15 @@ Check if the host has SMTP Server and the email really exists::
     from validate_email import validate_email
     is_valid = validate_email('example@example.com',verify=True)
 
+Verify email exists on a server that implements BATV
+-------------------
+
+Check if the host has SMTP Server and the email really exists::
+
+    from validate_email import validate_email
+    is_valid = validate_email('example@example.com',verify=True,sending_email="valid@example.org")
+
+valid@example.org must be a valid e-mail that you control.
 
 TODOs and BUGS
 ==============

--- a/validate_email.py
+++ b/validate_email.py
@@ -109,7 +109,8 @@ def get_mx_ip(hostname):
     return MX_DNS_CACHE[hostname]
 
 
-def validate_email(email, check_mx=False, verify=False, debug=False, smtp_timeout=10):
+def validate_email(email, check_mx=False, verify=False, debug=False,\
+    sending_email='', smtp_timeout=10):
     """Indicate whether the given string is a valid email address
     according to the 'addr-spec' portion of RFC 2822 (see section
     3.4.1).  Parts of the spec that are marked obsolete are *not*
@@ -153,7 +154,7 @@ def validate_email(email, check_mx=False, verify=False, debug=False, smtp_timeou
                         if debug:
                             logger.debug(u'%s answer: %s - %s', mx[1], status, _)
                         continue
-                    smtp.mail('')
+                    smtp.mail(sending_email)
                     status, _ = smtp.rcpt(email)
                     if status == 250:
                         smtp.quit()


### PR DESCRIPTION
The ability to specify the email of the "sender" (any valid email) is necessary in order to verify e-mails on servers that implement [BATV](https://en.wikipedia.org/wiki/Bounce_Address_Tag_Validation).

Fixes #41 .
