### PR TITLE
Enable email verification on servers that implement callback verification

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,17 @@ Check if the host has SMTP Server and the email really exists::
     from validate_email import validate_email
     is_valid = validate_email('example@example.com',verify=True)
 
+Verify email exists on a server that implements callback verfication
+-------------------
+
+Check if the host has SMTP Server and the email really exists::
+
+    from validate_email import validate_email
+    is_valid = validate_email('example@example.com',verify=True,sending_email="valid@example.org")
+
+valid@example.org must be a valid e-mail that you control.
+
+For information on callback verification see: https://en.wikipedia.org/wiki/Callback_verification
 
 TODOs and BUGS
 ==============

--- a/validate_email.py
+++ b/validate_email.py
@@ -109,7 +109,8 @@ def get_mx_ip(hostname):
     return MX_DNS_CACHE[hostname]
 
 
-def validate_email(email, check_mx=False, verify=False, debug=False, smtp_timeout=10):
+def validate_email(email, check_mx=False, verify=False, debug=False,\
+    sending_email='', smtp_timeout=10):
     """Indicate whether the given string is a valid email address
     according to the 'addr-spec' portion of RFC 2822 (see section
     3.4.1).  Parts of the spec that are marked obsolete are *not*
@@ -153,7 +154,7 @@ def validate_email(email, check_mx=False, verify=False, debug=False, smtp_timeou
                         if debug:
                             logger.debug(u'%s answer: %s - %s', mx[1], status, _)
                         continue
-                    smtp.mail('')
+                    smtp.mail(sending_email)
                     status, _ = smtp.rcpt(email)
                     if status == 250:
                         smtp.quit()


### PR DESCRIPTION
The current code fails to verify email addresses on servers that implement [callback verification](https://en.wikipedia.org/wiki/Callback_verification). This is because if those servers are not provided with a valid email during the MAIL command of the SMTP protocol they will not provide meaningful results when the RCPT command is issued. This can easily be fixed by providing a email address as the "sending address" to the verification method, and then passing that along to the SMTP server being queried.

This pull request doesn't change the default behavior of the module so that existing code will not be affected, but those who want to get valid results from servers implementing callback verification can get them by providing an additional optional argument.

Closes #41.
