### PR TITLE
Added generic exception catcher so as to make validation more resilient.

### DIFF
--- a/validate_email.py
+++ b/validate_email.py
@@ -167,6 +167,9 @@ def validate_email(email, check_mx=False, verify=False, debug=False, smtp_timeou
                 except smtplib.SMTPConnectError:
                     if debug:
                         logger.debug(u'Unable to connect to %s.', mx[1])
+                except Exception as e:
+                    if debug:
+                        logger.debug(u'Unknown error: %s.', str(e))
             return None
     except AssertionError:
         return False

--- a/validate_email.py
+++ b/validate_email.py
@@ -109,7 +109,7 @@ def get_mx_ip(hostname):
     return MX_DNS_CACHE[hostname]
 
 
-def validate_email(email, check_mx=False, verify=False, debug=False, smtp_timeout=10):
+def validate_email(email, check_mx=False, verify=False, debug=False, sending_email='', smtp_timeout=10):
     """Indicate whether the given string is a valid email address
     according to the 'addr-spec' portion of RFC 2822 (see section
     3.4.1).  Parts of the spec that are marked obsolete are *not*
@@ -153,7 +153,7 @@ def validate_email(email, check_mx=False, verify=False, debug=False, smtp_timeou
                         if debug:
                             logger.debug(u'%s answer: %s - %s', mx[1], status, _)
                         continue
-                    smtp.mail('')
+                    smtp.mail(sending_email)
                     status, _ = smtp.rcpt(email)
                     if status == 250:
                         smtp.quit()


### PR DESCRIPTION
This allows for the validation routine to work properly even if one of the MXes does not listen on port 25.
