### PR TITLE
Add `dns` extras in setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,10 @@ For check the domain mx and verify email exits you must have the `pyDNS` package
 
     pip install pyDNS
 
+or install them both in one step from the beginning::
+
+    pip install validate-email[dns]
+
 
 USAGE
 =====

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,8 @@ setup(name='validate_email',
       long_description=open('README.rst').read(),
       keywords = 'email validation verification mx verify',
       url = 'http://github.com/syrusakbary/validate_email',
+      extras_require = {
+            'dns:sys_platform != "win32"': ['pyDNS']
+      },
       license = 'LGPL',
     )


### PR DESCRIPTION
Add an `extras_require` section in ` setup.py` for installing `pyDNS` dependency  if not on Windows, and installed like this:

    pip install validate-email[dns]