### PR TITLE
Added instruction for Python 3 users for installing pyDNS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,10 @@ For check the domain mx and verify email exits you must have the `pyDNS` package
 
     pip install pyDNS
 
+For Python3
+
+	pip install py3DNS
+
 
 USAGE
 =====


### PR DESCRIPTION
I have added a simple instruction for Python 3 Users to install pyDNS. Because lots of people are facing the issue. If you can merge that would be useful for lots of python 3 users.